### PR TITLE
Bug fix: getName() of null label

### DIFF
--- a/src/Entity/Course.php
+++ b/src/Entity/Course.php
@@ -236,10 +236,12 @@ class Course implements \JsonSerializable
         }
         $arrayFiles = [];
         foreach($this->documents as $document){
+            $labelName = ($label = $document->getLabel()) ? $label->getName() : null ;
+
             $arrayFiles[] = [
                 "name" => $document->getName(),
                 "author" => $document->getAuthor()->getEmail(),
-                "label" => $document->getLabel()->getName(),
+                "label" => $labelName ,
                 "date" => $document->getUpdatedAt()];
         }
 


### PR DESCRIPTION
Course.php, dans jsonSerialize(), on faisait un getName() sur le label, mais on ne forcait pas un label != null